### PR TITLE
feat: add macOS tracker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,15 @@ Tauri, SvelteKit, TypeScript를 기반으로 제작되었습니다.
     pnpm tauri dev
     ```
 
-    macOS에서 게임 프로세스 메모리를 읽으려면 앱이 `com.apple.security.cs.debugger` entitlement로 서명되어야 합니다. 이 저장소의 macOS 번들 설정은 개인 개발/테스트 빌드에서 ad-hoc 서명(`signingIdentity: "-"`)과 `src-tauri/entitlements.plist`를 사용합니다.
+    macOS에서 게임 프로세스 메모리를 읽으려면 앱이 `com.apple.security.cs.debugger` entitlement로 서명되어야 합니다. 개인 개발/테스트 빌드에서 ad-hoc 서명이 필요하면 Tauri build config override로 `signingIdentity: "-"`를 지정할 수 있습니다.
+
+    개발자 계정 없이 개인 테스트/공유용 macOS DMG를 만들려면 다음처럼 ad-hoc 서명으로 빌드할 수 있습니다.
+
+    ```bash
+    pnpm tauri build --bundles dmg --config '{"bundle":{"createUpdaterArtifacts":false,"macOS":{"signingIdentity":"-"}}}'
+    ```
+
+    이 방식은 Developer ID 서명과 notarization을 거치지 않으므로, 다른 Mac에서 처음 열 때 Gatekeeper 경고가 표시될 수 있습니다.
 
 -----
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Tauri, SvelteKit, TypeScript를 기반으로 제작되었습니다.
     pnpm tauri dev
     ```
 
+    macOS에서 게임 프로세스 메모리를 읽으려면 앱이 `com.apple.security.cs.debugger` entitlement로 서명되어야 합니다. 이 저장소의 macOS 번들 설정은 개인 개발/테스트 빌드에서 ad-hoc 서명(`signingIdentity: "-"`)과 `src-tauri/entitlements.plist`를 사용합니다.
+
 -----
 
 ## 📂 프로젝트 구조
@@ -79,6 +81,7 @@ Tauri, SvelteKit, TypeScript를 기반으로 제작되었습니다.
 │   │   ├── peer_manager.rs   # WebRTC Peer 연결 관리
 │   │   ├── signaling_handler.rs # WebSocket 시그널링 처리
 │   │   ├── native_collector.rs # 게임 프로세스 데이터 수집
+│   │   ├── mac_proc.rs       # macOS 프로세스 메모리 접근
 │   │   └── win_proc.rs       # Windows 프로세스 메모리 접근
 │   ├── Cargo.toml            # Rust 의존성 관리
 │   └── tauri.conf.json       # Tauri 설정 파일

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2038,6 +2038,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "goblin"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17582616a7718cca54cec18e534a76c7c4aec11a8b9a85695712f262fd15a4c8"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3712,6 +3723,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plist"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4598,6 +4615,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scroll"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
 
 [[package]]
 name = "sdp"
@@ -7547,6 +7584,7 @@ dependencies = [
  "anyhow",
  "axum",
  "futures",
+ "goblin",
  "log",
  "rand 0.8.5",
  "reqwest 0.13.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,6 +56,9 @@ windows = { version = "0.62.2", features = [
     "Win32_Storage_Packaging_Appx",
 ] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+goblin = "0.10.7"
+
 [features]
 store = [] # MS Store용 플래그
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,7 +24,6 @@ tauri = { version = "2", features = ["tray-icon", "devtools"] }
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-winapi = { version = "0.3.9", features = ["handleapi", "memoryapi", "minwindef", "ntdef", "processthreadsapi", "psapi", "securitybaseapi", "shellapi", "tlhelp32", "winnt", "minwinbase", "winuser"] }
 tokio = "1.45.1"
 axum = { version = "0.8.8", features = ["ws"] }
 tracing = "0.1.40"
@@ -50,6 +49,7 @@ tauri-plugin-single-instance = "2.2.4"
 tauri-plugin-updater = "2.8.1"
 
 [target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3.9", features = ["handleapi", "memoryapi", "minwindef", "ntdef", "processthreadsapi", "psapi", "securitybaseapi", "shellapi", "tlhelp32", "winnt", "minwinbase", "winuser"] }
 windows = { version = "0.62.2", features = [
     "Services_Store",
     "Foundation",

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,8 +1,15 @@
 fn main() {
-    let mut windows = tauri_build::WindowsAttributes::new();
-    windows = windows.app_manifest(include_str!("admin.manifest"));
+    #[cfg(windows)]
+    {
+        let mut windows = tauri_build::WindowsAttributes::new();
+        windows = windows.app_manifest(include_str!("admin.manifest"));
 
-    tauri_build::try_build(
-        tauri_build::Attributes::new().windows_attributes(windows)
-    ).expect("failed to run tauri-build");
+        tauri_build::try_build(tauri_build::Attributes::new().windows_attributes(windows))
+            .expect("failed to run tauri-build");
+    }
+
+    #[cfg(not(windows))]
+    {
+        tauri_build::build();
+    }
 }

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.debugger</key>
+  <true/>
+</dict>
+</plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,7 @@
+#[cfg(target_os = "macos")]
+mod mac_proc;
 mod native_collector;
+mod offset_manager;
 mod offsets;
 mod peer_manager;
 mod room_code_generator;
@@ -6,11 +9,12 @@ mod rtc_supervisor;
 mod signaling_handler;
 mod types;
 mod util;
+#[cfg(windows)]
 mod win_proc;
-mod offset_manager;
 
 use std::sync::Arc;
 
+use crate::offsets::WuwaOffset;
 use crate::rtc_supervisor::RtcSupervisor;
 use crate::types::SupervisorCommand;
 use tauri::{
@@ -20,10 +24,15 @@ use tauri::{
 };
 use tauri_plugin_notification::NotificationExt;
 use tokio::sync::{Mutex, mpsc, oneshot};
-use windows::core::AgileReference;
 use types::{GlobalState, LocalStorageConfig};
 use util::get_config;
-use crate::offsets::WuwaOffset;
+#[cfg(all(feature = "store", windows))]
+use windows::core::AgileReference;
+
+#[cfg(windows)]
+const GAME_PROCESS_NAME: &str = "Client-Win64-Shipping.exe";
+#[cfg(target_os = "macos")]
+const GAME_PROCESS_NAME: &str = "Client-Mac-Shipping";
 
 struct TauriState {
     supervisor_tx: mpsc::Sender<SupervisorCommand>,
@@ -43,7 +52,7 @@ async fn find_and_attach(app_handle: AppHandle) -> Result<(), String> {
     state
         .supervisor_tx
         .send(SupervisorCommand::AttachProcess(
-            "Client-Win64-Shipping.exe".to_string(),
+            GAME_PROCESS_NAME.to_string(),
             resp_tx,
         ))
         .await
@@ -133,13 +142,15 @@ async fn channel_set_global_state(app_handle: AppHandle, value: GlobalState) -> 
     };
 }
 
-#[cfg(feature = "store")]
+#[cfg(all(feature = "store", windows))]
 async fn check_store_updates_background(app_handle: AppHandle) -> Result<(), String> {
     use windows::Services::Store::StoreContext;
 
     let context = StoreContext::GetDefault().map_err(|e| e.to_string())?;
-    let updates = context.GetAppAndOptionalStorePackageUpdatesAsync()
-        .map_err(|e| e.to_string())?.await
+    let updates = context
+        .GetAppAndOptionalStorePackageUpdatesAsync()
+        .map_err(|e| e.to_string())?
+        .await
         .map_err(|e| e.to_string())?;
 
     if updates.Size().map_err(|e| e.to_string())? > 0 {
@@ -147,14 +158,17 @@ async fn check_store_updates_background(app_handle: AppHandle) -> Result<(), Str
 
         let updates_agile = AgileReference::new(&updates).map_err(|e| e.to_string())?;
 
-        app_handle.run_on_main_thread(move || {
-            if let Ok(updates_resolved) = updates_agile.resolve() {
-                if let Ok(store_context) = StoreContext::GetDefault() {
-                    log::info!("Triggering store update dialog on main thread.");
-                    let _ = store_context.RequestDownloadAndInstallStorePackageUpdatesAsync(&updates_resolved);
+        app_handle
+            .run_on_main_thread(move || {
+                if let Ok(updates_resolved) = updates_agile.resolve() {
+                    if let Ok(store_context) = StoreContext::GetDefault() {
+                        log::info!("Triggering store update dialog on main thread.");
+                        let _ = store_context
+                            .RequestDownloadAndInstallStorePackageUpdatesAsync(&updates_resolved);
+                    }
                 }
-            }
-        }).map_err(|e| e.to_string())?;
+            })
+            .map_err(|e| e.to_string())?;
     }
     Ok(())
 }
@@ -191,7 +205,7 @@ pub async fn run() {
         .manage(TauriState {
             supervisor_tx,
             global_state: Arc::new(Mutex::new(GlobalState::default())),
-            offsets: offsets_shared
+            offsets: offsets_shared,
         })
         .plugin(tauri_plugin_dialog::init())
         .plugin(
@@ -259,7 +273,7 @@ pub async fn run() {
             let handle = app.handle().clone();
             tokio::spawn(async move {
                 let config = get_config(handle.clone()).await.unwrap_or_default();
-            
+
                 // 트레이 시작 설정
                 let start_in_tray = config.start_in_tray.unwrap_or(false);
                 if !start_in_tray {
@@ -268,11 +282,13 @@ pub async fn run() {
                         let _ = window.set_focus();
                     }
                 } else {
-                    if let Err(e) = handle.notification()
+                    if let Err(e) = handle
+                        .notification()
                         .builder()
                         .title("명조 맵스 트래커")
                         .body("프로그램이 시스템 트레이에서 실행 중입니다.")
-                        .show() {
+                        .show()
+                    {
                         log::error!("알림 발송 실패: {}", e);
                     }
                 }
@@ -288,7 +304,7 @@ pub async fn run() {
                     .await
             });
 
-            #[cfg(feature = "store")]
+            #[cfg(all(feature = "store", windows))]
             {
                 let handle = app.handle().clone();
                 tokio::spawn(async move {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod native_collector;
 mod offset_manager;
 mod offsets;
 mod peer_manager;
+mod process_backend;
 mod room_code_generator;
 mod rtc_supervisor;
 mod signaling_handler;

--- a/src-tauri/src/mac_proc.rs
+++ b/src-tauri/src/mac_proc.rs
@@ -1,7 +1,7 @@
 use crate::offsets::WuwaOffset;
-use crate::process_backend::{ProcessBackend, select_player_info};
+use crate::process_backend::ProcessBackend;
+use crate::types::NativeError;
 use crate::types::NativeError::PointerChainError;
-use crate::types::{NativeError, PlayerInfo};
 use anyhow::{Context, Result, bail};
 use goblin::mach::constants::cputype;
 use goblin::mach::load_command::CommandVariant;
@@ -59,7 +59,6 @@ pub struct MacProc {
     pid: c_int,
     task: MachTaskPort,
     gworld_symbol_addr: u64,
-    offset: Option<WuwaOffset>,
 }
 
 struct MachTaskPort {
@@ -134,30 +133,7 @@ impl MacProc {
             pid,
             task,
             gworld_symbol_addr,
-            offset: None,
         })
-    }
-
-    pub async fn get_location(
-        &mut self,
-        available_offsets: &Option<Vec<WuwaOffset>>,
-    ) -> Result<PlayerInfo, NativeError> {
-        let Some(variants) = available_offsets else {
-            return Err(PointerChainError {
-                message: "오프셋 데이터를 불러오는 중입니다...".to_string(),
-            });
-        };
-
-        let mut cached_offset = self.offset.take();
-        let result = select_player_info(self, &mut cached_offset, variants);
-        self.offset = cached_offset;
-        result
-    }
-
-    pub fn get_active_offset_name(&self) -> Option<String> {
-        self.offset
-            .as_ref()
-            .map(|o| <Self as ProcessBackend>::active_offset_name(self, o))
     }
 
     fn find_pid_by_name(name: &str) -> Option<c_int> {
@@ -308,13 +284,9 @@ impl MacProc {
         }
 
         let address = Self::symbol_address(path, symbol)?;
-        cache.entries.retain(|entry| {
-            !(entry.path == path_string
-                && entry.len == metadata.len()
-                && entry.modified_secs == modified_secs
-                && entry.uuid == uuid
-                && entry.symbol == symbol)
-        });
+        cache
+            .entries
+            .retain(|entry| !(entry.path == path_string && entry.symbol == symbol));
         cache.entries.push(GworldSymbolCacheEntry {
             path: path_string,
             len: metadata.len(),

--- a/src-tauri/src/mac_proc.rs
+++ b/src-tauri/src/mac_proc.rs
@@ -1,0 +1,348 @@
+use crate::offsets::WuwaOffset;
+use crate::types::NativeError::{PointerChainError, ValueReadError};
+use crate::types::{FIntVector, FTransformDouble, NativeError, PlayerInfo};
+use anyhow::{Context, Result, bail};
+use std::f32::consts::PI;
+use std::ffi::CStr;
+use std::mem;
+use std::os::raw::{c_char, c_int, c_uint, c_void};
+use std::path::Path;
+use std::process::Command;
+
+type KernReturn = i32;
+type MachPort = u32;
+type MachVmAddress = u64;
+type MachVmSize = u64;
+
+const KERN_SUCCESS: KernReturn = 0;
+const MACH_PORT_NULL: MachPort = 0;
+const MACH_EXECUTE_BASE_VMADDR: u64 = 0x1000_0000_0;
+const GWORLD_SYMBOL_NAME: &str = "_GWorld";
+const PROC_PIDPATHINFO_MAXSIZE: usize = 4096;
+
+unsafe extern "C" {
+    static mach_task_self_: MachPort;
+
+    fn task_for_pid(task: MachPort, pid: c_int, target_task: *mut MachPort) -> KernReturn;
+    fn mach_port_deallocate(task: MachPort, name: MachPort) -> KernReturn;
+    fn mach_vm_read_overwrite(
+        target_task: MachPort,
+        address: MachVmAddress,
+        size: MachVmSize,
+        data: MachVmAddress,
+        out_size: *mut MachVmSize,
+    ) -> KernReturn;
+    fn proc_pidpath(pid: c_int, buffer: *mut c_void, buffersize: c_uint) -> c_int;
+    fn kill(pid: c_int, sig: c_int) -> c_int;
+}
+
+pub struct MacProc {
+    pid: c_int,
+    task: MachPort,
+    gworld_symbol_addr: u64,
+    offset: Option<WuwaOffset>,
+}
+
+impl MacProc {
+    pub fn new(name: &str) -> Result<Self> {
+        let pid = Self::find_pid_by_name(name)
+            .with_context(|| "게임이 실행 중이 아닙니다.".to_string())?;
+        let task = Self::open_task(pid)?;
+        let process_path = Self::process_path(pid)?;
+        let load_addr = Self::load_address(pid)?;
+        let gworld_file_addr = Self::symbol_address(&process_path, GWORLD_SYMBOL_NAME)?;
+        let slide = load_addr.saturating_sub(MACH_EXECUTE_BASE_VMADDR);
+        let gworld_symbol_addr = gworld_file_addr + slide;
+
+        log::info!(
+            "Process '{}' connected! PID: {}, Load Address: {:X}, _GWorld: {:X}",
+            name,
+            pid,
+            load_addr,
+            gworld_symbol_addr
+        );
+
+        Ok(Self {
+            pid,
+            task,
+            gworld_symbol_addr,
+            offset: None,
+        })
+    }
+
+    pub fn is_alive(&self) -> bool {
+        unsafe { kill(self.pid, 0) == 0 }
+    }
+
+    pub async fn get_location(
+        &mut self,
+        available_offsets: &Option<Vec<WuwaOffset>>,
+    ) -> Result<PlayerInfo, NativeError> {
+        if !self.is_alive() {
+            return Err(NativeError::ProcessTerminated);
+        }
+
+        let Some(variants) = available_offsets else {
+            return Err(PointerChainError {
+                message: "오프셋 데이터를 불러오는 중입니다...".to_string(),
+            });
+        };
+
+        if let Some(offset) = &self.offset {
+            return self.get_location_with_offset(offset);
+        }
+
+        for (i, offset) in variants.iter().enumerate() {
+            if let Ok(location) = self.get_location_with_offset(offset) {
+                log::info!("Mac offset variant #{} ({}) succeeded.", i + 1, offset.name);
+                self.offset = Some(offset.clone());
+                return Ok(location);
+            }
+        }
+
+        Err(PointerChainError {
+            message: "사용 가능한 Mac 버전 값을 찾지 못했습니다.".to_string(),
+        })
+    }
+
+    pub fn get_active_offset_name(&self) -> Option<String> {
+        self.offset.as_ref().map(|o| format!("mac:{}", o.name))
+    }
+
+    fn get_location_with_offset(&self, offset: &WuwaOffset) -> Result<PlayerInfo, NativeError> {
+        let gworld = self
+            .read_memory::<u64>(self.gworld_symbol_addr)
+            .ok_or_else(|| PointerChainError {
+                message: format!(
+                    "_GWorld 위치 ({:X})의 주소 값을 읽지 못했습니다.",
+                    self.gworld_symbol_addr
+                ),
+            })?;
+
+        let targets = [
+            ("OwningGameInstance", offset.uworld_owninggameinstance),
+            ("TArray<*LocalPlayers>", offset.ugameinstance_localplayers),
+            ("LocalPlayer", 0),
+            ("PlayerController", offset.uplayer_playercontroller),
+            ("APawn", offset.aplayercontroller_acknowlegedpawn),
+            ("RootComponent", offset.aactor_rootcomponent),
+        ];
+
+        let mut last_addr = gworld;
+        for t in targets {
+            let target = last_addr + t.1;
+            last_addr = self
+                .read_memory::<u64>(target)
+                .ok_or_else(|| PointerChainError {
+                    message: format!("'{}' 위치 ({:X})의 주소 값을 읽지 못했습니다.", t.0, target),
+                })?;
+        }
+
+        let target = last_addr + offset.uscenecomponent_componenttoworld;
+        let location = self
+            .read_memory::<FTransformDouble>(target)
+            .ok_or_else(|| ValueReadError {
+                message: format!("FTransform 위치 ({:X})의 값을 읽지 못했습니다.", target),
+            })?;
+
+        let (roll, pitch, yaw) = Self::quat_to_euler(
+            location.rot_x,
+            location.rot_y,
+            location.rot_z,
+            location.rot_w,
+        );
+
+        let persistent_level_addr = gworld + offset.uworld_persistentlevel;
+        let persistent_level = self
+            .read_memory::<u64>(persistent_level_addr)
+            .ok_or_else(|| PointerChainError {
+                message: format!(
+                    "WorldOrigin을 위한 PersistentLevel 위치 ({:X})의 주소 값을 읽지 못했습니다.",
+                    persistent_level_addr
+                ),
+            })?;
+
+        let target = persistent_level + offset.ulevel_lastworldorigin;
+        let root_location =
+            self.read_memory::<FIntVector>(target)
+                .ok_or_else(|| ValueReadError {
+                    message: format!(
+                        "LastWorldOrigin 위치 ({:X})의 값을 읽지 못했습니다.",
+                        target
+                    ),
+                })?;
+
+        Ok(PlayerInfo {
+            x: location.loc_x + (root_location.x as f32),
+            y: location.loc_y + (root_location.y as f32),
+            z: location.loc_z + (root_location.z as f32),
+            pitch,
+            yaw,
+            roll,
+        })
+    }
+
+    fn read_memory<T: Copy>(&self, address: u64) -> Option<T> {
+        if address == 0 {
+            return None;
+        }
+
+        unsafe {
+            let mut buffer: T = mem::zeroed();
+            let mut bytes_read: MachVmSize = 0;
+            let success = mach_vm_read_overwrite(
+                self.task,
+                address,
+                mem::size_of::<T>() as MachVmSize,
+                &mut buffer as *mut T as MachVmAddress,
+                &mut bytes_read,
+            );
+
+            if success == KERN_SUCCESS && bytes_read == mem::size_of::<T>() as MachVmSize {
+                Some(buffer)
+            } else {
+                None
+            }
+        }
+    }
+
+    fn find_pid_by_name(name: &str) -> Option<c_int> {
+        let output = Command::new("/usr/bin/pgrep")
+            .arg("-x")
+            .arg(name)
+            .output()
+            .ok()?;
+
+        if !output.status.success() {
+            return None;
+        }
+
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .find_map(|line| line.trim().parse::<c_int>().ok())
+    }
+
+    fn open_task(pid: c_int) -> Result<MachPort> {
+        let mut task = MACH_PORT_NULL;
+        let kr = unsafe { task_for_pid(mach_task_self(), pid, &mut task) };
+        if kr != KERN_SUCCESS || task == MACH_PORT_NULL {
+            bail!(
+                "게임 프로세스 권한을 얻지 못했습니다. macOS에서는 com.apple.security.cs.debugger entitlement로 앱을 서명해야 합니다. kern_return={}",
+                kr
+            );
+        }
+        Ok(task)
+    }
+
+    fn process_path(pid: c_int) -> Result<String> {
+        let mut buffer = vec![0 as c_char; PROC_PIDPATHINFO_MAXSIZE];
+        let len = unsafe {
+            proc_pidpath(
+                pid,
+                buffer.as_mut_ptr() as *mut c_void,
+                PROC_PIDPATHINFO_MAXSIZE as c_uint,
+            )
+        };
+
+        if len <= 0 {
+            bail!("게임 실행 파일 경로를 확인하지 못했습니다.");
+        }
+
+        let path = unsafe { CStr::from_ptr(buffer.as_ptr()) }
+            .to_string_lossy()
+            .into_owned();
+        Ok(path)
+    }
+
+    fn load_address(pid: c_int) -> Result<u64> {
+        let output = Command::new("/usr/bin/vmmap")
+            .arg("-summary")
+            .arg(pid.to_string())
+            .output()
+            .context("vmmap 실행 실패")?;
+
+        if !output.status.success() {
+            bail!(
+                "게임 Load Address를 확인하지 못했습니다: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            let Some(value) = line.trim().strip_prefix("Load Address:") else {
+                continue;
+            };
+            let value = value.trim().trim_start_matches("0x");
+            return u64::from_str_radix(value, 16).context("Load Address 파싱 실패");
+        }
+
+        bail!("vmmap 출력에서 Load Address를 찾지 못했습니다.");
+    }
+
+    fn symbol_address(path: impl AsRef<Path>, symbol: &str) -> Result<u64> {
+        let output = Command::new("/usr/bin/nm")
+            .arg(path.as_ref())
+            .output()
+            .context("nm 실행 실패")?;
+
+        if !output.status.success() {
+            bail!(
+                "게임 심볼 테이블을 확인하지 못했습니다: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            let mut parts = line.split_whitespace();
+            let Some(address) = parts.next() else {
+                continue;
+            };
+            let _kind = parts.next();
+            let Some(name) = parts.next() else {
+                continue;
+            };
+            if name == symbol {
+                return u64::from_str_radix(address, 16)
+                    .with_context(|| format!("{} 주소 파싱 실패", symbol));
+            }
+        }
+
+        bail!("{} 심볼을 찾지 못했습니다.", symbol);
+    }
+
+    fn quat_to_euler(x: f32, y: f32, z: f32, w: f32) -> (f32, f32, f32) {
+        let sinr_cosp = 2.0 * (w * x + y * z);
+        let cosr_cosp = 1.0 - 2.0 * (x * x + y * y);
+        let roll = sinr_cosp.atan2(cosr_cosp);
+
+        let sinp = 2.0 * (w * y - z * x);
+        let pitch = if sinp.abs() >= 1.0 {
+            (PI / 2.0).copysign(sinp)
+        } else {
+            sinp.asin()
+        };
+
+        let siny_cosp = 2.0 * (w * z + x * y);
+        let cosy_cosp = 1.0 - 2.0 * (y * y + z * z);
+        let yaw = siny_cosp.atan2(cosy_cosp);
+
+        (roll * 180.0 / PI, pitch * 180.0 / PI, yaw * 180.0 / PI)
+    }
+}
+
+impl Drop for MacProc {
+    fn drop(&mut self) {
+        if self.task != MACH_PORT_NULL {
+            log::info!("Closing Mach task port for PID {}", self.pid);
+            unsafe {
+                mach_port_deallocate(mach_task_self(), self.task);
+            }
+        }
+    }
+}
+
+fn mach_task_self() -> MachPort {
+    unsafe { mach_task_self_ }
+}

--- a/src-tauri/src/mac_proc.rs
+++ b/src-tauri/src/mac_proc.rs
@@ -1,29 +1,46 @@
 use crate::offsets::WuwaOffset;
-use crate::types::NativeError::{PointerChainError, ValueReadError};
-use crate::types::{FIntVector, FTransformDouble, NativeError, PlayerInfo};
+use crate::process_backend::{ProcessBackend, select_player_info};
+use crate::types::NativeError::PointerChainError;
+use crate::types::{NativeError, PlayerInfo};
 use anyhow::{Context, Result, bail};
-use std::f32::consts::PI;
+use goblin::mach::constants::cputype;
+use goblin::mach::load_command::CommandVariant;
+use goblin::mach::{Mach, MachO, SingleArch};
+use serde::{Deserialize, Serialize};
 use std::ffi::CStr;
-use std::mem;
+use std::fs;
 use std::os::raw::{c_char, c_int, c_uint, c_void};
-use std::path::Path;
-use std::process::Command;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
 
 type KernReturn = i32;
 type MachPort = u32;
 type MachVmAddress = u64;
 type MachVmSize = u64;
+type Natural = u32;
+type MachMsgTypeNumber = u32;
 
 const KERN_SUCCESS: KernReturn = 0;
 const MACH_PORT_NULL: MachPort = 0;
 const MACH_EXECUTE_BASE_VMADDR: u64 = 0x1000_0000_0;
 const GWORLD_SYMBOL_NAME: &str = "_GWorld";
 const PROC_PIDPATHINFO_MAXSIZE: usize = 4096;
+const CACHE_FILE: &str = "mac_gworld_symbol_cache.json";
+const TASK_DYLD_INFO: c_int = 17;
+const TASK_DYLD_INFO_COUNT: MachMsgTypeNumber =
+    (std::mem::size_of::<TaskDyldInfo>() / std::mem::size_of::<Natural>()) as MachMsgTypeNumber;
+const MAX_REMOTE_PATH_LEN: usize = 4096;
 
 unsafe extern "C" {
     static mach_task_self_: MachPort;
 
     fn task_for_pid(task: MachPort, pid: c_int, target_task: *mut MachPort) -> KernReturn;
+    fn task_info(
+        target_task: MachPort,
+        flavor: c_int,
+        task_info_out: *mut Natural,
+        task_info_count: *mut MachMsgTypeNumber,
+    ) -> KernReturn;
     fn mach_port_deallocate(task: MachPort, name: MachPort) -> KernReturn;
     fn mach_vm_read_overwrite(
         target_task: MachPort,
@@ -32,27 +49,78 @@ unsafe extern "C" {
         data: MachVmAddress,
         out_size: *mut MachVmSize,
     ) -> KernReturn;
+    fn proc_listallpids(buffer: *mut c_void, buffersize: c_int) -> c_int;
+    fn proc_name(pid: c_int, buffer: *mut c_void, buffersize: c_uint) -> c_int;
     fn proc_pidpath(pid: c_int, buffer: *mut c_void, buffersize: c_uint) -> c_int;
     fn kill(pid: c_int, sig: c_int) -> c_int;
 }
 
 pub struct MacProc {
     pid: c_int,
-    task: MachPort,
+    task: MachTaskPort,
     gworld_symbol_addr: u64,
     offset: Option<WuwaOffset>,
 }
 
+struct MachTaskPort {
+    port: MachPort,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+struct GworldSymbolCache {
+    entries: Vec<GworldSymbolCacheEntry>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct GworldSymbolCacheEntry {
+    path: String,
+    len: u64,
+    modified_secs: u64,
+    #[serde(default)]
+    uuid: Option<String>,
+    symbol: String,
+    address: u64,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+struct TaskDyldInfo {
+    all_image_info_addr: u64,
+    all_image_info_size: u64,
+    all_image_info_format: c_int,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+struct DyldAllImageInfosPrefix {
+    version: u32,
+    info_array_count: u32,
+    info_array: u64,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+struct DyldImageInfo {
+    image_load_address: u64,
+    image_file_path: u64,
+    image_file_mod_date: u64,
+}
+
 impl MacProc {
-    pub fn new(name: &str) -> Result<Self> {
+    pub fn new(name: &str, cache_dir: PathBuf) -> Result<Self> {
         let pid = Self::find_pid_by_name(name)
             .with_context(|| "게임이 실행 중이 아닙니다.".to_string())?;
-        let task = Self::open_task(pid)?;
+        let task = MachTaskPort::open(pid)?;
         let process_path = Self::process_path(pid)?;
-        let load_addr = Self::load_address(pid)?;
-        let gworld_file_addr = Self::symbol_address(&process_path, GWORLD_SYMBOL_NAME)?;
-        let slide = load_addr.saturating_sub(MACH_EXECUTE_BASE_VMADDR);
-        let gworld_symbol_addr = gworld_file_addr + slide;
+        let load_addr = Self::load_address(&task, &process_path)?;
+        let gworld_file_addr =
+            Self::symbol_address_with_cache(&process_path, GWORLD_SYMBOL_NAME, &cache_dir)?;
+        let slide = load_addr
+            .checked_sub(MACH_EXECUTE_BASE_VMADDR)
+            .with_context(|| format!("잘못된 Mach-O Load Address: {:X}", load_addr))?;
+        let gworld_symbol_addr = gworld_file_addr
+            .checked_add(slide)
+            .context("_GWorld 런타임 주소 계산 overflow")?;
 
         log::info!(
             "Process '{}' connected! PID: {}, Load Address: {:X}, _GWorld: {:X}",
@@ -70,168 +138,79 @@ impl MacProc {
         })
     }
 
-    pub fn is_alive(&self) -> bool {
-        unsafe { kill(self.pid, 0) == 0 }
-    }
-
     pub async fn get_location(
         &mut self,
         available_offsets: &Option<Vec<WuwaOffset>>,
     ) -> Result<PlayerInfo, NativeError> {
-        if !self.is_alive() {
-            return Err(NativeError::ProcessTerminated);
-        }
-
         let Some(variants) = available_offsets else {
             return Err(PointerChainError {
                 message: "오프셋 데이터를 불러오는 중입니다...".to_string(),
             });
         };
 
-        if let Some(offset) = &self.offset {
-            return self.get_location_with_offset(offset);
-        }
-
-        for (i, offset) in variants.iter().enumerate() {
-            if let Ok(location) = self.get_location_with_offset(offset) {
-                log::info!("Mac offset variant #{} ({}) succeeded.", i + 1, offset.name);
-                self.offset = Some(offset.clone());
-                return Ok(location);
-            }
-        }
-
-        Err(PointerChainError {
-            message: "사용 가능한 Mac 버전 값을 찾지 못했습니다.".to_string(),
-        })
+        let mut cached_offset = self.offset.take();
+        let result = select_player_info(self, &mut cached_offset, variants);
+        self.offset = cached_offset;
+        result
     }
 
     pub fn get_active_offset_name(&self) -> Option<String> {
-        self.offset.as_ref().map(|o| format!("mac:{}", o.name))
-    }
-
-    fn get_location_with_offset(&self, offset: &WuwaOffset) -> Result<PlayerInfo, NativeError> {
-        let gworld = self
-            .read_memory::<u64>(self.gworld_symbol_addr)
-            .ok_or_else(|| PointerChainError {
-                message: format!(
-                    "_GWorld 위치 ({:X})의 주소 값을 읽지 못했습니다.",
-                    self.gworld_symbol_addr
-                ),
-            })?;
-
-        let targets = [
-            ("OwningGameInstance", offset.uworld_owninggameinstance),
-            ("TArray<*LocalPlayers>", offset.ugameinstance_localplayers),
-            ("LocalPlayer", 0),
-            ("PlayerController", offset.uplayer_playercontroller),
-            ("APawn", offset.aplayercontroller_acknowlegedpawn),
-            ("RootComponent", offset.aactor_rootcomponent),
-        ];
-
-        let mut last_addr = gworld;
-        for t in targets {
-            let target = last_addr + t.1;
-            last_addr = self
-                .read_memory::<u64>(target)
-                .ok_or_else(|| PointerChainError {
-                    message: format!("'{}' 위치 ({:X})의 주소 값을 읽지 못했습니다.", t.0, target),
-                })?;
-        }
-
-        let target = last_addr + offset.uscenecomponent_componenttoworld;
-        let location = self
-            .read_memory::<FTransformDouble>(target)
-            .ok_or_else(|| ValueReadError {
-                message: format!("FTransform 위치 ({:X})의 값을 읽지 못했습니다.", target),
-            })?;
-
-        let (roll, pitch, yaw) = Self::quat_to_euler(
-            location.rot_x,
-            location.rot_y,
-            location.rot_z,
-            location.rot_w,
-        );
-
-        let persistent_level_addr = gworld + offset.uworld_persistentlevel;
-        let persistent_level = self
-            .read_memory::<u64>(persistent_level_addr)
-            .ok_or_else(|| PointerChainError {
-                message: format!(
-                    "WorldOrigin을 위한 PersistentLevel 위치 ({:X})의 주소 값을 읽지 못했습니다.",
-                    persistent_level_addr
-                ),
-            })?;
-
-        let target = persistent_level + offset.ulevel_lastworldorigin;
-        let root_location =
-            self.read_memory::<FIntVector>(target)
-                .ok_or_else(|| ValueReadError {
-                    message: format!(
-                        "LastWorldOrigin 위치 ({:X})의 값을 읽지 못했습니다.",
-                        target
-                    ),
-                })?;
-
-        Ok(PlayerInfo {
-            x: location.loc_x + (root_location.x as f32),
-            y: location.loc_y + (root_location.y as f32),
-            z: location.loc_z + (root_location.z as f32),
-            pitch,
-            yaw,
-            roll,
-        })
-    }
-
-    fn read_memory<T: Copy>(&self, address: u64) -> Option<T> {
-        if address == 0 {
-            return None;
-        }
-
-        unsafe {
-            let mut buffer: T = mem::zeroed();
-            let mut bytes_read: MachVmSize = 0;
-            let success = mach_vm_read_overwrite(
-                self.task,
-                address,
-                mem::size_of::<T>() as MachVmSize,
-                &mut buffer as *mut T as MachVmAddress,
-                &mut bytes_read,
-            );
-
-            if success == KERN_SUCCESS && bytes_read == mem::size_of::<T>() as MachVmSize {
-                Some(buffer)
-            } else {
-                None
-            }
-        }
+        self.offset
+            .as_ref()
+            .map(|o| <Self as ProcessBackend>::active_offset_name(self, o))
     }
 
     fn find_pid_by_name(name: &str) -> Option<c_int> {
-        let output = Command::new("/usr/bin/pgrep")
-            .arg("-x")
-            .arg(name)
-            .output()
-            .ok()?;
+        let mut capacity = 2048usize;
+        loop {
+            let mut pids = vec![0 as c_int; capacity];
+            let count = unsafe {
+                proc_listallpids(
+                    pids.as_mut_ptr() as *mut c_void,
+                    (pids.len() * std::mem::size_of::<c_int>()) as c_int,
+                )
+            };
 
-        if !output.status.success() {
+            if count <= 0 {
+                return None;
+            }
+
+            let count = count as usize;
+            if count >= capacity {
+                capacity *= 2;
+                continue;
+            }
+
+            return pids.into_iter().take(count).find(|pid| {
+                if *pid <= 0 {
+                    return false;
+                }
+                Self::process_name(*pid)
+                    .as_deref()
+                    .is_some_and(|process_name| process_name == name)
+            });
+        }
+    }
+
+    fn process_name(pid: c_int) -> Option<String> {
+        let mut buffer = vec![0 as c_char; PROC_PIDPATHINFO_MAXSIZE];
+        let len = unsafe {
+            proc_name(
+                pid,
+                buffer.as_mut_ptr() as *mut c_void,
+                PROC_PIDPATHINFO_MAXSIZE as c_uint,
+            )
+        };
+
+        if len <= 0 {
             return None;
         }
 
-        String::from_utf8_lossy(&output.stdout)
-            .lines()
-            .find_map(|line| line.trim().parse::<c_int>().ok())
-    }
-
-    fn open_task(pid: c_int) -> Result<MachPort> {
-        let mut task = MACH_PORT_NULL;
-        let kr = unsafe { task_for_pid(mach_task_self(), pid, &mut task) };
-        if kr != KERN_SUCCESS || task == MACH_PORT_NULL {
-            bail!(
-                "게임 프로세스 권한을 얻지 못했습니다. macOS에서는 com.apple.security.cs.debugger entitlement로 앱을 서명해야 합니다. kern_return={}",
-                kr
-            );
-        }
-        Ok(task)
+        Some(
+            unsafe { CStr::from_ptr(buffer.as_ptr()) }
+                .to_string_lossy()
+                .into_owned(),
+        )
     }
 
     fn process_path(pid: c_int) -> Result<String> {
@@ -254,92 +233,348 @@ impl MacProc {
         Ok(path)
     }
 
-    fn load_address(pid: c_int) -> Result<u64> {
-        let output = Command::new("/usr/bin/vmmap")
-            .arg("-summary")
-            .arg(pid.to_string())
-            .output()
-            .context("vmmap 실행 실패")?;
-
-        if !output.status.success() {
-            bail!(
-                "게임 Load Address를 확인하지 못했습니다: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
+    fn load_address(task: &MachTaskPort, process_path: &str) -> Result<u64> {
+        let dyld_info = task.dyld_info()?;
+        let infos = task.read_memory::<DyldAllImageInfosPrefix>(dyld_info.all_image_info_addr)?;
+        if infos.info_array_count == 0 || infos.info_array == 0 {
+            bail!("dyld image list가 비어 있습니다.");
         }
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        for line in stdout.lines() {
-            let Some(value) = line.trim().strip_prefix("Load Address:") else {
+        let process_file_name = Path::new(process_path)
+            .file_name()
+            .and_then(|name| name.to_str());
+        let mut file_name_match = None;
+
+        for i in 0..infos.info_array_count {
+            let address =
+                infos.info_array + (i as u64 * std::mem::size_of::<DyldImageInfo>() as u64);
+            let image = task.read_memory::<DyldImageInfo>(address)?;
+            if image.image_load_address == 0 || image.image_file_path == 0 {
                 continue;
-            };
-            let value = value.trim().trim_start_matches("0x");
-            return u64::from_str_radix(value, 16).context("Load Address 파싱 실패");
+            }
+
+            let path = task.read_remote_c_string(image.image_file_path, MAX_REMOTE_PATH_LEN)?;
+            if path == process_path {
+                return Ok(image.image_load_address);
+            }
+
+            if file_name_match.is_none()
+                && process_file_name.is_some_and(|name| {
+                    Path::new(&path)
+                        .file_name()
+                        .and_then(|image_name| image_name.to_str())
+                        .is_some_and(|image_name| image_name == name)
+                })
+            {
+                file_name_match = Some(image.image_load_address);
+            }
         }
 
-        bail!("vmmap 출력에서 Load Address를 찾지 못했습니다.");
+        file_name_match.with_context(|| {
+            "dyld image list에서 main executable load address를 찾지 못했습니다.".to_string()
+        })
+    }
+
+    fn symbol_address_with_cache(
+        path: impl AsRef<Path>,
+        symbol: &str,
+        cache_dir: &Path,
+    ) -> Result<u64> {
+        let path = path.as_ref();
+        let metadata = fs::metadata(path).context("게임 실행 파일 metadata 확인 실패")?;
+        let path_string = path.to_string_lossy().into_owned();
+        let uuid = Self::macho_uuid(path).unwrap_or_else(|e| {
+            log::warn!("Failed to read Mach-O UUID for cache key: {}", e);
+            None
+        });
+        let modified_secs = metadata
+            .modified()
+            .ok()
+            .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+            .map(|value| value.as_secs())
+            .unwrap_or_default();
+        let cache_path = cache_dir.join(CACHE_FILE);
+        let mut cache = Self::load_symbol_cache(&cache_path);
+
+        if let Some(entry) = cache.entries.iter().find(|entry| {
+            entry.path == path_string
+                && entry.len == metadata.len()
+                && entry.modified_secs == modified_secs
+                && entry.uuid == uuid
+                && entry.symbol == symbol
+        }) {
+            log::info!("Using cached Mach-O symbol {}: {:X}", symbol, entry.address);
+            return Ok(entry.address);
+        }
+
+        let address = Self::symbol_address(path, symbol)?;
+        cache.entries.retain(|entry| {
+            !(entry.path == path_string
+                && entry.len == metadata.len()
+                && entry.modified_secs == modified_secs
+                && entry.uuid == uuid
+                && entry.symbol == symbol)
+        });
+        cache.entries.push(GworldSymbolCacheEntry {
+            path: path_string,
+            len: metadata.len(),
+            modified_secs,
+            uuid,
+            symbol: symbol.to_string(),
+            address,
+        });
+        Self::save_symbol_cache(&cache_path, &cache);
+        Ok(address)
+    }
+
+    fn load_symbol_cache(path: &Path) -> GworldSymbolCache {
+        let Ok(data) = fs::read_to_string(path) else {
+            return GworldSymbolCache::default();
+        };
+        serde_json::from_str(&data).unwrap_or_default()
+    }
+
+    fn save_symbol_cache(path: &Path, cache: &GworldSymbolCache) {
+        if let Some(parent) = path.parent() {
+            if let Err(e) = fs::create_dir_all(parent) {
+                log::warn!("Failed to create symbol cache dir: {}", e);
+                return;
+            }
+        }
+        match serde_json::to_string(cache) {
+            Ok(data) => {
+                if let Err(e) = fs::write(path, data) {
+                    log::warn!("Failed to write symbol cache: {}", e);
+                }
+            }
+            Err(e) => log::warn!("Failed to serialize symbol cache: {}", e),
+        }
     }
 
     fn symbol_address(path: impl AsRef<Path>, symbol: &str) -> Result<u64> {
-        let output = Command::new("/usr/bin/nm")
-            .arg(path.as_ref())
-            .output()
-            .context("nm 실행 실패")?;
+        let bytes = fs::read(path.as_ref()).context("게임 Mach-O 파일 읽기 실패")?;
+        match Mach::parse(&bytes).context("Mach-O 파싱 실패")? {
+            Mach::Binary(macho) => Self::symbol_address_from_macho(&macho, symbol),
+            Mach::Fat(fat) => {
+                let cputype = current_cputype();
+                if let Some(arch) = fat.find_cputype(cputype).context("Fat Mach-O 탐색 실패")? {
+                    let macho = MachO::parse(&bytes, arch.offset as usize)
+                        .context("Mach-O arch 파싱 실패")?;
+                    return Self::symbol_address_from_macho(&macho, symbol);
+                }
 
-        if !output.status.success() {
-            bail!(
-                "게임 심볼 테이블을 확인하지 못했습니다: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
+                for i in 0..fat.narches {
+                    match fat.get(i) {
+                        Ok(SingleArch::MachO(macho)) => {
+                            if let Ok(address) = Self::symbol_address_from_macho(&macho, symbol) {
+                                return Ok(address);
+                            }
+                        }
+                        Ok(SingleArch::Archive(_)) => {}
+                        Err(e) => log::debug!("Skipping Mach-O arch: {}", e),
+                    }
+                }
+                bail!("현재 CPU arch에서 {} 심볼을 찾지 못했습니다.", symbol)
+            }
         }
+    }
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        for line in stdout.lines() {
-            let mut parts = line.split_whitespace();
-            let Some(address) = parts.next() else {
-                continue;
-            };
-            let _kind = parts.next();
-            let Some(name) = parts.next() else {
-                continue;
-            };
+    fn symbol_address_from_macho(macho: &MachO<'_>, symbol: &str) -> Result<u64> {
+        for item in macho.symbols() {
+            let (name, nlist) = item.context("Mach-O 심볼 읽기 실패")?;
             if name == symbol {
-                return u64::from_str_radix(address, 16)
-                    .with_context(|| format!("{} 주소 파싱 실패", symbol));
+                return Ok(nlist.n_value);
             }
         }
 
         bail!("{} 심볼을 찾지 못했습니다.", symbol);
     }
 
-    fn quat_to_euler(x: f32, y: f32, z: f32, w: f32) -> (f32, f32, f32) {
-        let sinr_cosp = 2.0 * (w * x + y * z);
-        let cosr_cosp = 1.0 - 2.0 * (x * x + y * y);
-        let roll = sinr_cosp.atan2(cosr_cosp);
+    fn macho_uuid(path: impl AsRef<Path>) -> Result<Option<String>> {
+        let bytes = fs::read(path.as_ref()).context("게임 Mach-O 파일 읽기 실패")?;
+        match Mach::parse(&bytes).context("Mach-O 파싱 실패")? {
+            Mach::Binary(macho) => Ok(Self::uuid_from_macho(&macho)),
+            Mach::Fat(fat) => {
+                let cputype = current_cputype();
+                if let Some(arch) = fat.find_cputype(cputype).context("Fat Mach-O 탐색 실패")? {
+                    let macho = MachO::parse(&bytes, arch.offset as usize)
+                        .context("Mach-O arch 파싱 실패")?;
+                    return Ok(Self::uuid_from_macho(&macho));
+                }
 
-        let sinp = 2.0 * (w * y - z * x);
-        let pitch = if sinp.abs() >= 1.0 {
-            (PI / 2.0).copysign(sinp)
-        } else {
-            sinp.asin()
+                for i in 0..fat.narches {
+                    match fat.get(i) {
+                        Ok(SingleArch::MachO(macho)) => {
+                            if let Some(uuid) = Self::uuid_from_macho(&macho) {
+                                return Ok(Some(uuid));
+                            }
+                        }
+                        Ok(SingleArch::Archive(_)) => {}
+                        Err(e) => log::debug!("Skipping Mach-O arch for UUID: {}", e),
+                    }
+                }
+                Ok(None)
+            }
+        }
+    }
+
+    fn uuid_from_macho(macho: &MachO<'_>) -> Option<String> {
+        macho.load_commands.iter().find_map(|command| {
+            if let CommandVariant::Uuid(uuid_command) = &command.command {
+                Some(
+                    uuid_command
+                        .uuid
+                        .iter()
+                        .map(|byte| format!("{:02x}", byte))
+                        .collect::<String>(),
+                )
+            } else {
+                None
+            }
+        })
+    }
+}
+
+impl ProcessBackend for MacProc {
+    fn is_alive(&self) -> bool {
+        unsafe { kill(self.pid, 0) == 0 }
+    }
+
+    fn read_bytes(&self, address: u64, buffer: &mut [u8]) -> Result<(), NativeError> {
+        self.task
+            .read_bytes(address, buffer)
+            .map_err(|e| NativeError::ValueReadError {
+                message: e.to_string(),
+            })
+    }
+
+    fn read_gworld(&self, _offset: &WuwaOffset) -> Result<u64, NativeError> {
+        self.read_memory::<u64>(self.gworld_symbol_addr)
+            .map_err(|e| PointerChainError {
+                message: format!(
+                    "_GWorld 위치 ({:X})의 주소 값을 읽지 못했습니다: {}",
+                    self.gworld_symbol_addr, e
+                ),
+            })
+    }
+
+    fn active_offset_name(&self, offset: &WuwaOffset) -> String {
+        format!("mac:{}", offset.name)
+    }
+}
+
+impl MachTaskPort {
+    fn open(pid: c_int) -> Result<Self> {
+        let mut port = MACH_PORT_NULL;
+        let kr = unsafe { task_for_pid(mach_task_self(), pid, &mut port) };
+        if kr != KERN_SUCCESS || port == MACH_PORT_NULL {
+            bail!(
+                "게임 프로세스 권한을 얻지 못했습니다. macOS에서는 com.apple.security.cs.debugger entitlement로 앱을 서명해야 합니다. kern_return={}",
+                kr
+            );
+        }
+        Ok(Self { port })
+    }
+
+    fn dyld_info(&self) -> Result<TaskDyldInfo> {
+        let mut info = TaskDyldInfo::default();
+        let mut count = TASK_DYLD_INFO_COUNT;
+        let kr = unsafe {
+            task_info(
+                self.port,
+                TASK_DYLD_INFO,
+                &mut info as *mut TaskDyldInfo as *mut Natural,
+                &mut count,
+            )
+        };
+        if kr != KERN_SUCCESS {
+            bail!("TASK_DYLD_INFO 조회 실패: kern_return={}", kr);
+        }
+        Ok(info)
+    }
+
+    fn read_memory<T: Copy>(&self, address: u64) -> Result<T> {
+        let mut value = std::mem::MaybeUninit::<T>::uninit();
+        let buffer = unsafe {
+            std::slice::from_raw_parts_mut(value.as_mut_ptr() as *mut u8, std::mem::size_of::<T>())
+        };
+        self.read_bytes(address, buffer)
+            .with_context(|| format!("원격 메모리 읽기 실패: {:X}", address))?;
+        Ok(unsafe { value.assume_init() })
+    }
+
+    fn read_remote_c_string(&self, address: u64, max_len: usize) -> Result<String> {
+        let mut bytes = Vec::new();
+        let mut current = address;
+        while bytes.len() < max_len {
+            let mut chunk = [0u8; 256];
+            self.read_bytes(current, &mut chunk)
+                .with_context(|| format!("원격 문자열 읽기 실패: {:X}", current))?;
+            if let Some(end) = chunk.iter().position(|byte| *byte == 0) {
+                bytes.extend_from_slice(&chunk[..end]);
+                return Ok(String::from_utf8_lossy(&bytes).into_owned());
+            }
+            bytes.extend_from_slice(&chunk);
+            current += chunk.len() as u64;
+        }
+
+        bail!("원격 문자열이 너무 깁니다.");
+    }
+
+    fn read_bytes(&self, address: u64, buffer: &mut [u8]) -> Result<()> {
+        if address == 0 {
+            bail!("원격 메모리 주소가 0입니다.");
+        }
+
+        let mut bytes_read: MachVmSize = 0;
+        let success = unsafe {
+            mach_vm_read_overwrite(
+                self.port,
+                address,
+                buffer.len() as MachVmSize,
+                buffer.as_mut_ptr() as MachVmAddress,
+                &mut bytes_read,
+            )
         };
 
-        let siny_cosp = 2.0 * (w * z + x * y);
-        let cosy_cosp = 1.0 - 2.0 * (y * y + z * z);
-        let yaw = siny_cosp.atan2(cosy_cosp);
+        if success == KERN_SUCCESS && bytes_read == buffer.len() as MachVmSize {
+            Ok(())
+        } else {
+            bail!(
+                "mach_vm_read_overwrite 실패: kern_return={}, bytes_read={}/{}",
+                success,
+                bytes_read,
+                buffer.len()
+            )
+        }
+    }
+}
 
-        (roll * 180.0 / PI, pitch * 180.0 / PI, yaw * 180.0 / PI)
+impl Drop for MachTaskPort {
+    fn drop(&mut self) {
+        if self.port != MACH_PORT_NULL {
+            unsafe {
+                mach_port_deallocate(mach_task_self(), self.port);
+            }
+        }
     }
 }
 
 impl Drop for MacProc {
     fn drop(&mut self) {
-        if self.task != MACH_PORT_NULL {
-            log::info!("Closing Mach task port for PID {}", self.pid);
-            unsafe {
-                mach_port_deallocate(mach_task_self(), self.task);
-            }
-        }
+        log::info!("Closing Mach task port for PID {}", self.pid);
+    }
+}
+
+fn current_cputype() -> u32 {
+    #[cfg(target_arch = "aarch64")]
+    {
+        cputype::CPU_TYPE_ARM64
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        cputype::CPU_TYPE_X86_64
     }
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,38 +1,6 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
-#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-
-use winapi::um::processthreadsapi::OpenProcessToken;
-use winapi::um::securitybaseapi::GetTokenInformation;
-use winapi::um::winnt::{HANDLE, TOKEN_ELEVATION, TOKEN_QUERY, TokenElevation};
+#![cfg_attr(all(windows, not(debug_assertions)), windows_subsystem = "windows")]
 
 fn main() {
     wuma_tracker_lib::run()
-}
-
-fn is_elevated() -> bool {
-    let mut is_elevated = false;
-    unsafe {
-        let mut token: HANDLE = std::ptr::null_mut();
-        if OpenProcessToken(
-            winapi::um::processthreadsapi::GetCurrentProcess(),
-            TOKEN_QUERY,
-            &mut token,
-        ) != 0
-        {
-            let mut elevation = TOKEN_ELEVATION { TokenIsElevated: 0 };
-            let mut size = std::mem::size_of::<TOKEN_ELEVATION>() as u32;
-            if GetTokenInformation(
-                token,
-                TokenElevation,
-                &mut elevation as *mut _ as *mut _,
-                size,
-                &mut size,
-            ) != 0
-            {
-                is_elevated = elevation.TokenIsElevated != 0;
-            }
-            winapi::um::handleapi::CloseHandle(token);
-        }
-    }
-    is_elevated
 }

--- a/src-tauri/src/native_collector.rs
+++ b/src-tauri/src/native_collector.rs
@@ -1,20 +1,23 @@
+#[cfg(target_os = "macos")]
+use crate::mac_proc::MacProc as PlatformProc;
+use crate::offsets::WuwaOffset;
 use crate::types::{CollectorMessage, NativeError};
-use crate::win_proc::WinProc;
+#[cfg(windows)]
+use crate::win_proc::WinProc as PlatformProc;
 use anyhow::Result;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, mpsc, oneshot};
-use crate::offsets::WuwaOffset;
 
-/// 단순 Windows Process Wrapper
+/// OS별 게임 프로세스 래퍼
 pub struct NativeCollector {
-    win_proc: WinProc,
+    proc: PlatformProc,
 }
 
 impl NativeCollector {
     pub async fn new(proc_name: &str) -> Result<Self> {
-        let win_proc = WinProc::new(proc_name)?;
-        Ok(Self { win_proc })
+        let proc = PlatformProc::new(proc_name)?;
+        Ok(Self { proc })
     }
 }
 
@@ -41,13 +44,17 @@ pub async fn collection_loop(
             let offsets_guard = offsets_arc.lock().await;
 
             // 3. get_location을 호출하고 결과를 매칭합니다.
-            match collector.win_proc.get_location(&*offsets_guard).await {
+            match collector.proc.get_location(&*offsets_guard).await {
                 // 성공 시 데이터 전송
                 Ok(loc) => {
                     if !offset_reported {
-                        if let Some(name) = collector.win_proc.get_active_offset_name() {
+                        if let Some(name) = collector.proc.get_active_offset_name() {
                             // RtcSupervisor에게 OffsetFound 메시지를 보냅니다.
-                            if pm_tx.send(CollectorMessage::OffsetFound(name)).await.is_err() {
+                            if pm_tx
+                                .send(CollectorMessage::OffsetFound(name))
+                                .await
+                                .is_err()
+                            {
                                 log::info!("Collection loop exiting: no receiver");
                                 break;
                             }

--- a/src-tauri/src/native_collector.rs
+++ b/src-tauri/src/native_collector.rs
@@ -4,7 +4,11 @@ use crate::offsets::WuwaOffset;
 use crate::types::{CollectorMessage, NativeError};
 #[cfg(windows)]
 use crate::win_proc::WinProc as PlatformProc;
+
+#[cfg(not(any(windows, target_os = "macos")))]
+compile_error!("Native process tracking is supported only on Windows and macOS.");
 use anyhow::Result;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, mpsc, oneshot};
@@ -15,8 +19,10 @@ pub struct NativeCollector {
 }
 
 impl NativeCollector {
-    pub async fn new(proc_name: &str) -> Result<Self> {
-        let proc = PlatformProc::new(proc_name)?;
+    pub async fn new(proc_name: &str, cache_dir: PathBuf) -> Result<Self> {
+        let proc_name = proc_name.to_string();
+        let proc =
+            tokio::task::spawn_blocking(move || PlatformProc::new(&proc_name, cache_dir)).await??;
         Ok(Self { proc })
     }
 }
@@ -27,7 +33,7 @@ pub async fn collection_loop(
     mut shutdown_rx: oneshot::Receiver<()>,
     offsets_arc: Arc<Mutex<Option<Vec<WuwaOffset>>>>,
 ) {
-    let mut offset_reported = false;
+    let mut reported_offset: Option<String> = None;
     loop {
         // Work Phase
         {
@@ -47,18 +53,18 @@ pub async fn collection_loop(
             match collector.proc.get_location(&*offsets_guard).await {
                 // 성공 시 데이터 전송
                 Ok(loc) => {
-                    if !offset_reported {
-                        if let Some(name) = collector.proc.get_active_offset_name() {
+                    if let Some(name) = collector.proc.get_active_offset_name() {
+                        if reported_offset.as_deref() != Some(name.as_str()) {
                             // RtcSupervisor에게 OffsetFound 메시지를 보냅니다.
                             if pm_tx
-                                .send(CollectorMessage::OffsetFound(name))
+                                .send(CollectorMessage::OffsetFound(name.clone()))
                                 .await
                                 .is_err()
                             {
                                 log::info!("Collection loop exiting: no receiver");
                                 break;
                             }
-                            offset_reported = true; // 보고 완료로 표시
+                            reported_offset = Some(name);
                         }
                     }
                     if pm_tx.send(CollectorMessage::Data(loc)).await.is_err() {

--- a/src-tauri/src/native_collector.rs
+++ b/src-tauri/src/native_collector.rs
@@ -1,6 +1,8 @@
 #[cfg(target_os = "macos")]
 use crate::mac_proc::MacProc as PlatformProc;
 use crate::offsets::WuwaOffset;
+use crate::process_backend::{ProcessBackend, select_player_info};
+use crate::types::NativeError::PointerChainError;
 use crate::types::{CollectorMessage, NativeError};
 #[cfg(windows)]
 use crate::win_proc::WinProc as PlatformProc;
@@ -16,6 +18,7 @@ use tokio::sync::{Mutex, mpsc, oneshot};
 /// OS별 게임 프로세스 래퍼
 pub struct NativeCollector {
     proc: PlatformProc,
+    offset: Option<WuwaOffset>,
 }
 
 impl NativeCollector {
@@ -23,7 +26,26 @@ impl NativeCollector {
         let proc_name = proc_name.to_string();
         let proc =
             tokio::task::spawn_blocking(move || PlatformProc::new(&proc_name, cache_dir)).await??;
-        Ok(Self { proc })
+        Ok(Self { proc, offset: None })
+    }
+
+    fn get_location(
+        &mut self,
+        available_offsets: &Option<Vec<WuwaOffset>>,
+    ) -> Result<crate::types::PlayerInfo, NativeError> {
+        let Some(variants) = available_offsets else {
+            return Err(PointerChainError {
+                message: "오프셋 데이터를 불러오는 중입니다...".to_string(),
+            });
+        };
+
+        select_player_info(&self.proc, &mut self.offset, variants)
+    }
+
+    fn get_active_offset_name(&self) -> Option<String> {
+        self.offset
+            .as_ref()
+            .map(|offset| self.proc.active_offset_name(offset))
     }
 }
 
@@ -35,8 +57,8 @@ pub async fn collection_loop(
 ) {
     let mut reported_offset: Option<String> = None;
     loop {
-        // Work Phase
-        {
+        let offsets_snapshot = offsets_arc.lock().await.clone();
+        let result = {
             // 1. 상태 관리자를 잠그고 공유 상태에 접근합니다.
             let mut collector_opt_guard = collector_arc.lock().await;
 
@@ -47,49 +69,60 @@ pub async fn collection_loop(
                 break;
             };
 
-            let offsets_guard = offsets_arc.lock().await;
-
             // 3. get_location을 호출하고 결과를 매칭합니다.
-            match collector.proc.get_location(&*offsets_guard).await {
+            match collector.get_location(&offsets_snapshot) {
                 // 성공 시 데이터 전송
                 Ok(loc) => {
-                    if let Some(name) = collector.proc.get_active_offset_name() {
-                        if reported_offset.as_deref() != Some(name.as_str()) {
-                            // RtcSupervisor에게 OffsetFound 메시지를 보냅니다.
-                            if pm_tx
-                                .send(CollectorMessage::OffsetFound(name.clone()))
-                                .await
-                                .is_err()
-                            {
-                                log::info!("Collection loop exiting: no receiver");
-                                break;
-                            }
-                            reported_offset = Some(name);
-                        }
-                    }
-                    if pm_tx.send(CollectorMessage::Data(loc)).await.is_err() {
-                        log::info!("Collection loop exiting: no receiver");
-                        break;
-                    }
+                    let offset_name = collector.get_active_offset_name();
+                    Ok((loc, offset_name))
                 }
 
                 // '프로세스 종료'는 치명적 오류
-                Err(NativeError::ProcessTerminated) => {
-                    log::info!("Collection loop exiting: process is terminated");
-                    let _ = pm_tx.send(CollectorMessage::Terminated).await;
-                    break;
-                }
+                Err(NativeError::ProcessTerminated) => Err(NativeError::ProcessTerminated),
 
                 // 그 외 모든 오류는 일시적인 것으로 간주
-                Err(e) => {
-                    if pm_tx
-                        .send(CollectorMessage::TemporalError(e.to_string()))
-                        .await
-                        .is_err()
-                    {
-                        log::info!("Collection loop exiting: no receiver");
-                        break;
+                Err(e) => Err(e),
+            }
+        };
+
+        match result {
+            Ok((loc, offset_name)) => {
+                if let Some(name) = offset_name {
+                    if reported_offset.as_deref() != Some(name.as_str()) {
+                        // RtcSupervisor에게 OffsetFound 메시지를 보냅니다.
+                        if pm_tx
+                            .send(CollectorMessage::OffsetFound(name.clone()))
+                            .await
+                            .is_err()
+                        {
+                            log::info!("Collection loop exiting: no receiver");
+                            break;
+                        }
+                        reported_offset = Some(name);
                     }
+                }
+                if pm_tx.send(CollectorMessage::Data(loc)).await.is_err() {
+                    log::info!("Collection loop exiting: no receiver");
+                    break;
+                }
+            }
+
+            // '프로세스 종료'는 치명적 오류
+            Err(NativeError::ProcessTerminated) => {
+                log::info!("Collection loop exiting: process is terminated");
+                let _ = pm_tx.send(CollectorMessage::Terminated).await;
+                break;
+            }
+
+            // 그 외 모든 오류는 일시적인 것으로 간주
+            Err(e) => {
+                if pm_tx
+                    .send(CollectorMessage::TemporalError(e.to_string()))
+                    .await
+                    .is_err()
+                {
+                    log::info!("Collection loop exiting: no receiver");
+                    break;
                 }
             }
         }

--- a/src-tauri/src/process_backend.rs
+++ b/src-tauri/src/process_backend.rs
@@ -1,0 +1,165 @@
+use crate::offsets::WuwaOffset;
+use crate::types::NativeError::{PointerChainError, ValueReadError};
+use crate::types::{FIntVector, FTransformDouble, NativeError, PlayerInfo};
+use std::f32::consts::PI;
+use std::mem::{self, MaybeUninit};
+
+pub trait ProcessBackend {
+    fn is_alive(&self) -> bool;
+    fn read_bytes(&self, address: u64, buffer: &mut [u8]) -> Result<(), NativeError>;
+    fn read_gworld(&self, offset: &WuwaOffset) -> Result<u64, NativeError>;
+    fn active_offset_name(&self, offset: &WuwaOffset) -> String {
+        offset.name.clone()
+    }
+
+    fn read_memory<T: Copy>(&self, address: u64) -> Result<T, NativeError> {
+        if address == 0 {
+            return Err(PointerChainError {
+                message: "원격 메모리 주소가 0입니다.".to_string(),
+            });
+        }
+
+        unsafe {
+            let mut value = MaybeUninit::<T>::uninit();
+            let buffer =
+                std::slice::from_raw_parts_mut(value.as_mut_ptr() as *mut u8, mem::size_of::<T>());
+
+            self.read_bytes(address, buffer)?;
+            Ok(value.assume_init())
+        }
+    }
+}
+
+pub fn select_player_info<B: ProcessBackend>(
+    backend: &B,
+    cached_offset: &mut Option<WuwaOffset>,
+    offsets: &[WuwaOffset],
+) -> Result<PlayerInfo, NativeError> {
+    if !backend.is_alive() {
+        return Err(NativeError::ProcessTerminated);
+    }
+
+    if let Some(offset) = cached_offset.clone() {
+        match read_player_info(backend, &offset) {
+            Ok(location) => return Ok(location),
+            Err(e) => {
+                log::warn!(
+                    "Cached offset {} failed, retrying all variants: {}",
+                    backend.active_offset_name(&offset),
+                    e
+                );
+                *cached_offset = None;
+            }
+        }
+    }
+
+    for (i, offset) in offsets.iter().enumerate() {
+        if let Ok(location) = read_player_info(backend, offset) {
+            log::info!(
+                "Offset variant #{} ({}) succeeded.",
+                i + 1,
+                backend.active_offset_name(offset)
+            );
+            *cached_offset = Some(offset.clone());
+            return Ok(location);
+        }
+    }
+
+    Err(PointerChainError {
+        message: "사용 가능한 버전 값을 찾지 못했습니다.".to_string(),
+    })
+}
+
+fn read_player_info<B: ProcessBackend>(
+    backend: &B,
+    offset: &WuwaOffset,
+) -> Result<PlayerInfo, NativeError> {
+    let gworld = backend.read_gworld(offset)?;
+
+    let targets = [
+        ("OwningGameInstance", offset.uworld_owninggameinstance),
+        ("TArray<*LocalPlayers>", offset.ugameinstance_localplayers),
+        ("LocalPlayer", 0),
+        ("PlayerController", offset.uplayer_playercontroller),
+        ("APawn", offset.aplayercontroller_acknowlegedpawn),
+        ("RootComponent", offset.aactor_rootcomponent),
+    ];
+
+    let mut last_addr = gworld;
+    for (name, field_offset) in targets {
+        let target = last_addr + field_offset;
+        last_addr = backend
+            .read_memory::<u64>(target)
+            .map_err(|e| PointerChainError {
+                message: format!(
+                    "'{}' 위치 ({:X})의 주소 값을 읽지 못했습니다: {}",
+                    name, target, e
+                ),
+            })?;
+    }
+
+    let transform_addr = last_addr + offset.uscenecomponent_componenttoworld;
+    let location = backend
+        .read_memory::<FTransformDouble>(transform_addr)
+        .map_err(|e| ValueReadError {
+            message: format!(
+                "FTransform 위치 ({:X})의 값을 읽지 못했습니다: {}",
+                transform_addr, e
+            ),
+        })?;
+
+    let (roll, pitch, yaw) = quat_to_euler(
+        location.rot_x,
+        location.rot_y,
+        location.rot_z,
+        location.rot_w,
+    );
+
+    let persistent_level_addr = gworld + offset.uworld_persistentlevel;
+    let persistent_level = backend
+        .read_memory::<u64>(persistent_level_addr)
+        .map_err(|e| PointerChainError {
+            message: format!(
+                "WorldOrigin을 위한 PersistentLevel 위치 ({:X})의 주소 값을 읽지 못했습니다: {}",
+                persistent_level_addr, e
+            ),
+        })?;
+
+    let world_origin_addr = persistent_level + offset.ulevel_lastworldorigin;
+    let root_location = backend
+        .read_memory::<FIntVector>(world_origin_addr)
+        .map_err(|e| ValueReadError {
+            message: format!(
+                "LastWorldOrigin 위치 ({:X})의 값을 읽지 못했습니다: {}",
+                world_origin_addr, e
+            ),
+        })?;
+
+    Ok(PlayerInfo {
+        x: location.loc_x + (root_location.x as f32),
+        y: location.loc_y + (root_location.y as f32),
+        z: location.loc_z + (root_location.z as f32),
+        pitch,
+        yaw,
+        roll,
+    })
+}
+
+fn quat_to_euler(x: f32, y: f32, z: f32, w: f32) -> (f32, f32, f32) {
+    let sinr_cosp = 2.0 * (w * x + y * z);
+    let cosr_cosp = 1.0 - 2.0 * (x * x + y * y);
+    let roll = sinr_cosp.atan2(cosr_cosp);
+
+    let sinp = 2.0 * (w * y - z * x);
+    let pitch = if sinp.abs() >= 1.0 {
+        (PI / 2.0).copysign(sinp)
+    } else {
+        sinp.asin()
+    };
+
+    let siny_cosp = 2.0 * (w * z + x * y);
+    let cosy_cosp = 1.0 - 2.0 * (y * y + z * z);
+    let yaw = siny_cosp.atan2(cosy_cosp);
+
+    (roll * 180.0 / PI, pitch * 180.0 / PI, yaw * 180.0 / PI)
+}

--- a/src-tauri/src/process_backend.rs
+++ b/src-tauri/src/process_backend.rs
@@ -39,18 +39,18 @@ pub fn select_player_info<B: ProcessBackend>(
         return Err(NativeError::ProcessTerminated);
     }
 
-    if let Some(offset) = cached_offset.clone() {
-        match read_player_info(backend, &offset) {
+    if let Some(offset) = cached_offset.as_ref() {
+        match read_player_info(backend, offset) {
             Ok(location) => return Ok(location),
             Err(e) => {
                 log::warn!(
                     "Cached offset {} failed, retrying all variants: {}",
-                    backend.active_offset_name(&offset),
+                    backend.active_offset_name(offset),
                     e
                 );
-                *cached_offset = None;
             }
         }
+        *cached_offset = None;
     }
 
     for (i, offset) in offsets.iter().enumerate() {

--- a/src-tauri/src/rtc_supervisor.rs
+++ b/src-tauri/src/rtc_supervisor.rs
@@ -1,4 +1,5 @@
 use crate::native_collector::{NativeCollector, collection_loop};
+use crate::offsets::WuwaOffset;
 use crate::peer_manager::PeerManager; // 이전 코드에서 정의
 use crate::room_code_generator::generate_room_code_base36;
 use crate::signaling_handler::SignalingHandler;
@@ -6,9 +7,8 @@ use crate::types::{CollectorMessage, GlobalState, RtcSignal, SignalPacket, Super
 use crate::util;
 use anyhow::Result;
 use std::sync::Arc;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::{Mutex, mpsc, oneshot};
-use crate::offsets::WuwaOffset;
 
 struct CollectorState {
     instance: Arc<Mutex<Option<NativeCollector>>>,
@@ -74,14 +74,18 @@ impl RtcSupervisor {
     ) -> Result<(), String> {
         log::info!("Starting RtcSupervisor...");
 
-        if let Err(e) = self.signaling_handler
+        if let Err(e) = self
+            .signaling_handler
             .restart_local_server(app_handle.clone(), ip, port)
-            .await 
+            .await
         {
-            log::error!("Failed to start SignalingHandler (Port might be in use): {}", e);
-        
+            log::error!(
+                "Failed to start SignalingHandler (Port might be in use): {}",
+                e
+            );
+
             let error_message = format!("서버 시작 실패 (포트 {}): {}", port, e);
-            
+
             if let Err(emit_err) = app_handle.emit("report-error-toast", error_message) {
                 log::error!("Failed to emit error to frontend: {}", emit_err);
             }
@@ -178,7 +182,7 @@ impl RtcSupervisor {
                                 log::error!("Restart local signaling server failed: {}", e);
 
                                 let error_message = format!("서버 시작 실패 (포트 {}): {}", port, e);
-            
+
                                 if let Err(emit_err) = app_handle.emit("report-error-toast", error_message) {
                                     log::error!("Failed to emit error to frontend: {}", emit_err);
                                 }
@@ -226,7 +230,11 @@ impl RtcSupervisor {
         }
 
         // log::info!("Attempting to attach to process: {}", proc_name);
-        match NativeCollector::new(proc_name).await {
+        let cache_dir = app_handle
+            .path()
+            .app_config_dir()
+            .map_err(|e| e.to_string())?;
+        match NativeCollector::new(proc_name, cache_dir).await {
             Ok(collector) => {
                 *self.collector_state.instance.lock().await = Some(collector);
                 log::info!("Process attached successfully.");

--- a/src-tauri/src/win_proc.rs
+++ b/src-tauri/src/win_proc.rs
@@ -1,14 +1,10 @@
-use std::{ffi::CStr, mem, ptr::null_mut};
-use std::f32::consts::PI;
-use std::sync::Arc;
-use crate::types::{FTransformDouble, NativeError};
+use std::{ffi::CStr, mem, path::PathBuf, ptr::null_mut};
+
+use crate::process_backend::{ProcessBackend, select_player_info};
+use crate::types::NativeError;
 use crate::types::NativeError::{PointerChainError, ValueReadError};
-use crate::{
-    offsets::WuwaOffset,
-    types::{FIntVector, PlayerInfo},
-};
+use crate::{offsets::WuwaOffset, types::PlayerInfo};
 use anyhow::{Context, Result, bail};
-use tokio::sync::Mutex;
 use winapi::um::minwinbase::STILL_ACTIVE;
 use winapi::um::processthreadsapi::GetExitCodeProcess;
 use winapi::{
@@ -36,7 +32,7 @@ pub struct WinProc {
 impl WinProc {
     /// 프로세스 이름으로 WinProc 인스턴스를 생성합니다.
     /// PID 찾기, 핸들 열기, 베이스 주소 가져오기를 모두 수행합니다.
-    pub fn new(name: &str) -> Result<Self> {
+    pub fn new(name: &str, _cache_dir: PathBuf) -> Result<Self> {
         unsafe {
             let pid = Self::find_pid_by_name(name)
                 .with_context(|| "게임이 실행 중이 아닙니다.".to_string())?;
@@ -84,80 +80,24 @@ impl WinProc {
         }
     }
 
-    /// 프로세스가 여전히 실행 중인지 확인합니다.
-    pub fn is_alive(&self) -> bool {
-        if self.handle.is_null() {
-            return false;
-        }
-        unsafe {
-            let mut exit_code: DWORD = 0;
-            if GetExitCodeProcess(self.handle, &mut exit_code) != 0 {
-                return exit_code == STILL_ACTIVE;
-            }
-            false
-        }
-    }
-
-    pub async fn get_location(&mut self, available_offsets: &Option<Vec<WuwaOffset>>) -> Result<PlayerInfo, NativeError> {
-        if !self.is_alive() {
-            return Err(NativeError::ProcessTerminated);
-        }
-
+    pub async fn get_location(
+        &mut self,
+        available_offsets: &Option<Vec<WuwaOffset>>,
+    ) -> Result<PlayerInfo, NativeError> {
         let Some(variants) = available_offsets else {
             return Err(PointerChainError {
                 message: "오프셋 데이터를 불러오는 중입니다...".to_string(),
             });
         };
 
-        // 이미 성공한 오프셋이 있다면 그것을 사용합니다.
-        if let Some(offset) = &self.offset {
-            return self.get_location_with_offset(offset);
-        }
-
-        // 성공한 오프셋이 없다면, 모든 변형을 시도합니다.
-        for (i, offset) in variants.iter().enumerate() {
-            if let Ok(location) = self.get_location_with_offset(offset) {
-                log::info!("Offset variant #{} ({}) succeeded. Caching it.", i + 1, offset.name);
-                // 성공하면 오프셋을 저장하고 결과를 반환합니다.
-                self.offset = Some(offset.clone());
-                return Ok(location);
-            }
-        }
-        
-        // 모든 오프셋이 실패한 경우 에러를 반환합니다.
-        Err(PointerChainError {
-            message: "사용 가능한 버전 값을 찾지 못했습니다.".to_string(),
-        })
+        let mut cached_offset = self.offset.take();
+        let result = select_player_info(self, &mut cached_offset, variants);
+        self.offset = cached_offset;
+        result
     }
 
     pub fn get_active_offset_name(&self) -> Option<String> {
         self.offset.as_ref().map(|o| o.name.clone())
-    }
-
-    // 이 메서드는 이제 private으로 만들어 외부에서 직접 호출하지 않도록 할 수 있습니다.
-    fn read_memory<T: Copy>(&self, address: u64) -> Option<T> {
-        // 주소 0은 유효하지 않으므로 미리 차단합니다. 포인터 체인이 끊겼을 때 흔히 발생합니다.
-        if address == 0 {
-            return None;
-        }
-        unsafe {
-            let mut buffer: T = mem::zeroed();
-            let mut bytes_read = 0;
-
-            let success = ReadProcessMemory(
-                self.handle,
-                address as *const c_void,
-                &mut buffer as *mut T as *mut c_void,
-                mem::size_of::<T>(),
-                &mut bytes_read,
-            );
-
-            if success != 0 && bytes_read == mem::size_of::<T>() {
-                Some(buffer)
-            } else {
-                None
-            }
-        }
     }
 
     // 헬퍼 함수로 분리하여 new에서 사용
@@ -186,86 +126,59 @@ impl WinProc {
         CloseHandle(h_process_snap);
         None
     }
+}
 
-    fn quat_to_euler(x: f32, y: f32, z: f32, w: f32) -> (f32, f32, f32) {
-        // 언리얼 엔진 좌표계 변환 로직
-        // Roll (X축 회전)
-        let sinr_cosp = 2.0 * (w * x + y * z);
-        let cosr_cosp = 1.0 - 2.0 * (x * x + y * y);
-        let roll = sinr_cosp.atan2(cosr_cosp);
-
-        // Pitch (Y축 회전)
-        let sinp = 2.0 * (w * y - z * x);
-        let pitch = if sinp.abs() >= 1.0 {
-            (PI / 2.0).copysign(sinp) // 90도 제한
-        } else {
-            sinp.asin()
-        };
-
-        // Yaw (Z축 회전)
-        let siny_cosp = 2.0 * (w * z + x * y);
-        let cosy_cosp = 1.0 - 2.0 * (y * y + z * z);
-        let yaw = siny_cosp.atan2(cosy_cosp);
-
-        // 라디안 -> 도(Degree) 변환
-        ((roll * 180.0 / PI), (pitch * 180.0 / PI), (yaw * 180.0 / PI))
+impl ProcessBackend for WinProc {
+    fn is_alive(&self) -> bool {
+        if self.handle.is_null() {
+            return false;
+        }
+        unsafe {
+            let mut exit_code: DWORD = 0;
+            if GetExitCodeProcess(self.handle, &mut exit_code) != 0 {
+                return exit_code == STILL_ACTIVE;
+            }
+            false
+        }
     }
 
-    fn get_location_with_offset(&self, offset: &WuwaOffset) -> Result<PlayerInfo, NativeError> {
-        let targets = [
-            ("GWorld", offset.global_gworld),
-            ("OwningGameInstance", offset.uworld_owninggameinstance),
-            ("TArray<*LocalPlayers>", offset.ugameinstance_localplayers),
-            ("LocalPlayer", 0),
-            ("PlayerController", offset.uplayer_playercontroller),
-            ("APawn", offset.aplayercontroller_acknowlegedpawn),
-            ("RootComponent", offset.aactor_rootcomponent),
-        ];
+    fn read_bytes(&self, address: u64, buffer: &mut [u8]) -> Result<(), NativeError> {
+        unsafe {
+            let mut bytes_read = 0;
 
-        let mut last_addr = self.base_addr;
-        for t in targets {
-            let target = last_addr + t.1;
-            last_addr = self.read_memory::<u64>(target).ok_or_else(|| PointerChainError {
-                message: format!("'{}' 위치 ({:X})의 주소 값을 읽지 못했습니다.", t.0, target),
-            })?;
+            let success = ReadProcessMemory(
+                self.handle,
+                address as *const c_void,
+                buffer.as_mut_ptr() as *mut c_void,
+                buffer.len(),
+                &mut bytes_read,
+            );
+
+            if success != 0 && bytes_read == buffer.len() {
+                Ok(())
+            } else {
+                Err(ValueReadError {
+                    message: format!(
+                        "ReadProcessMemory 실패: address={:X}, bytes_read={}/{}",
+                        address,
+                        bytes_read,
+                        buffer.len()
+                    ),
+                })
+            }
         }
-
-        let target = last_addr + offset.uscenecomponent_componenttoworld;
-        let location = self.read_memory::<FTransformDouble>(target).ok_or_else(|| ValueReadError {
-            message: format!("FTransform 위치 ({:X})의 값을 읽지 못했습니다.", target),
-        })?;
-
-        let (roll, pitch, yaw) = Self::quat_to_euler(location.rot_x, location.rot_y, location.rot_z, location.rot_w);
-
-        let target_worldorigin = [
-            ("GWorld", offset.global_gworld),
-            ("PersistentLevel", offset.uworld_persistentlevel),
-        ];
-
-        last_addr = self.base_addr;
-        for t in target_worldorigin {
-            let target = last_addr + t.1;
-            last_addr = self.read_memory::<u64>(target).ok_or_else(|| PointerChainError {
-                message: format!("WorldOrigin을 위한 '{}' 위치 ({:X})의 주소 값을 읽지 못했습니다.", t.0, target),
-            })?;
-        }
-
-        let target = last_addr + offset.ulevel_lastworldorigin;
-        let root_location = self.read_memory::<FIntVector>(target).ok_or_else(|| ValueReadError {
-            message: format!("LastWorldOrigin 위치 ({:X})의 값을 읽지 못했습니다.", target),
-        })?;
-
-        Ok(PlayerInfo {
-            x: location.loc_x + (root_location.x as f32),
-            y: location.loc_y + (root_location.y as f32),
-            z: location.loc_z + (root_location.z as f32),
-            pitch,
-            yaw,
-            roll,
-        })
     }
 
-
+    fn read_gworld(&self, offset: &WuwaOffset) -> Result<u64, NativeError> {
+        let target = self.base_addr + offset.global_gworld;
+        self.read_memory::<u64>(target)
+            .map_err(|e| PointerChainError {
+                message: format!(
+                    "'GWorld' 위치 ({:X})의 주소 값을 읽지 못했습니다: {}",
+                    target, e
+                ),
+            })
+    }
 }
 
 impl Drop for WinProc {

--- a/src-tauri/src/win_proc.rs
+++ b/src-tauri/src/win_proc.rs
@@ -1,9 +1,9 @@
 use std::{ffi::CStr, mem, path::PathBuf, ptr::null_mut};
 
-use crate::process_backend::{ProcessBackend, select_player_info};
+use crate::offsets::WuwaOffset;
+use crate::process_backend::ProcessBackend;
 use crate::types::NativeError;
 use crate::types::NativeError::{PointerChainError, ValueReadError};
-use crate::{offsets::WuwaOffset, types::PlayerInfo};
 use anyhow::{Context, Result, bail};
 use winapi::um::minwinbase::STILL_ACTIVE;
 use winapi::um::processthreadsapi::GetExitCodeProcess;
@@ -26,7 +26,6 @@ pub struct WinProc {
     pid: u32,
     pub base_addr: u64,
     handle: HANDLE,
-    offset: Option<WuwaOffset>,
 }
 
 impl WinProc {
@@ -75,29 +74,8 @@ impl WinProc {
                 pid,
                 base_addr: h_mod as u64,
                 handle,
-                offset: None,
             })
         }
-    }
-
-    pub async fn get_location(
-        &mut self,
-        available_offsets: &Option<Vec<WuwaOffset>>,
-    ) -> Result<PlayerInfo, NativeError> {
-        let Some(variants) = available_offsets else {
-            return Err(PointerChainError {
-                message: "오프셋 데이터를 불러오는 중입니다...".to_string(),
-            });
-        };
-
-        let mut cached_offset = self.offset.take();
-        let result = select_player_info(self, &mut cached_offset, variants);
-        self.offset = cached_offset;
-        result
-    }
-
-    pub fn get_active_offset_name(&self) -> Option<String> {
-        self.offset.as_ref().map(|o| o.name.clone())
     }
 
     // 헬퍼 함수로 분리하여 new에서 사용

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,6 +36,10 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "macOS": {
+      "signingIdentity": "-",
+      "entitlements": "entitlements.plist"
+    },
     "windows": {
       "wix": {
         "language": "ko-KR",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,7 +37,6 @@
       "icons/icon.ico"
     ],
     "macOS": {
-      "signingIdentity": "-",
       "entitlements": "entitlements.plist"
     },
     "windows": {


### PR DESCRIPTION
## Summary

Adds macOS support for the native tracker while keeping the existing Windows implementation intact.

- adds a macOS process reader for `Client-Mac-Shipping`
- resolves `_GWorld` from the Mach-O symbol table with `goblin` and applies the ASLR slide from dyld image info
- replaces macOS helper commands with native APIs (`proc_listallpids`, `proc_name`, `task_info(TASK_DYLD_INFO)`, `mach_vm_read_overwrite`)
- caches the Mach-O `_GWorld` symbol address under the app config directory, keyed by path/size/mtime/LC_UUID/symbol
- extracts the shared post-`GWorld` UE pointer chain into `ProcessBackend`
- shares `quat_to_euler` through the common backend module
- keeps ad-hoc signing as a local build override instead of hardcoding it in `tauri.conf.json`
- documents the macOS debugger entitlement and personal-use DMG build command

## 요약

기존 Windows 트래커 구조는 유지하면서 macOS 전용 네이티브 트래커 백엔드를 추가했습니다.

- macOS 게임 클라이언트 `Client-Mac-Shipping` 프로세스를 찾아 연결합니다.
- `goblin`으로 Mach-O 심볼 테이블에서 `_GWorld` 주소를 찾고, dyld image info로 ASLR slide를 계산합니다.
- macOS 경로의 외부 명령 실행(`pgrep`, `vmmap`, `nm`)을 네이티브 API로 대체했습니다.
- `_GWorld` Mach-O 심볼 주소를 앱 설정 디렉터리에 캐싱합니다. 캐시 키에는 path/size/mtime/LC_UUID/symbol을 사용합니다.
- `_GWorld` 이후의 UE 포인터 체인은 `ProcessBackend` 공통 로직으로 분리했습니다.
- `quat_to_euler` 중복 구현도 공통 모듈로 이동했습니다.
- `signingIdentity: "-"`는 기본 설정에서 제거하고, 개인 개발/테스트 빌드용 config override로 문서화했습니다.
- 개발자 계정 없이 개인 공유용 DMG를 만들 수 있는 ad-hoc 서명 빌드 명령을 README에 추가했습니다.

## Offset/version maintenance

The “version value” is the per-game-version entry in `tracker-offsets.json` (`name`, `uworld_persistentlevel`, `uworld_owninggameinstance`, etc.). The app loads that list from `https://wuwa.moe/tracker-offsets.json` and tries entries until the pointer chain succeeds.

For macOS, this PR does not depend on the JSON `global_gworld` value. `MacProc` resolves `_GWorld` from the game Mach-O binary with `goblin`, finds the loaded main image through `task_info(TASK_DYLD_INFO)`, then applies the ASLR slide. After `_GWorld`, macOS reuses the same UE field offsets as Windows.

So when a new game version is released:

1. If only `_GWorld` changes, macOS should keep working because `_GWorld` is resolved automatically.
2. If UE object field offsets change, update/add the matching `tracker-offsets.json` entry as before.
3. To identify the active entry, run the tracker and check the displayed/logged offset name, e.g. `mac:v3.3.0`.

## 오프셋/버전값 관리 방법

여기서 말하는 “버전값”은 `tracker-offsets.json`에 들어가는 게임 버전별 오프셋 항목입니다. 예를 들면 `name: v3.3.0`, `uworld_persistentlevel`, `uworld_owninggameinstance` 같은 값들입니다. 앱은 `https://wuwa.moe/tracker-offsets.json`에서 이 목록을 받아오고, 각 항목을 순서대로 시도해서 포인터 체인이 성공하는 값을 사용합니다.

macOS에서는 이 PR이 JSON의 `global_gworld` 값에 의존하지 않습니다. `MacProc`가 `goblin`으로 게임 실행 파일의 Mach-O 심볼 테이블에서 `_GWorld`를 찾고, `task_info(TASK_DYLD_INFO)`로 로드된 main image 주소를 읽은 뒤 ASLR slide를 적용합니다. `_GWorld` 이후의 UE 필드 오프셋은 기존 Windows와 같은 `tracker-offsets.json` 값을 재사용합니다.

따라서 새 게임 버전이 나왔을 때 기준은 이렇습니다.

1. `_GWorld` 주소만 바뀐 경우: macOS는 자동 탐색하므로 별도 수정 없이 동작할 가능성이 높습니다.
2. UE 객체 필드 오프셋이 바뀐 경우: 기존처럼 `tracker-offsets.json`에 새 버전 항목을 추가/수정해야 합니다.
3. 실제 어떤 항목을 잡았는지는 트래커 화면/로그의 `mac:v3.3.0` 같은 active offset 이름으로 확인할 수 있습니다.

## Notes

macOS requires the app binary to be signed with `com.apple.security.cs.debugger` for `task_for_pid` to read the game process memory.

For personal/dev builds without an Apple Developer account, ad-hoc signing can be used:

```bash
pnpm tauri build --bundles dmg --config '{"bundle":{"createUpdaterArtifacts":false,"macOS":{"signingIdentity":"-"}}}'
```

This creates a non-notarized DMG. Other Macs may show a Gatekeeper warning on first launch.

## 참고

macOS에서 게임 프로세스 메모리를 읽으려면 앱 바이너리가 `com.apple.security.cs.debugger` entitlement로 서명되어 있어야 합니다.

Apple Developer 계정이 없는 개인 개발/테스트 빌드는 아래처럼 ad-hoc 서명으로 DMG를 만들 수 있습니다.

```bash
pnpm tauri build --bundles dmg --config '{"bundle":{"createUpdaterArtifacts":false,"macOS":{"signingIdentity":"-"}}}'
```

이 방식은 Developer ID 서명과 notarization을 거치지 않으므로, 다른 Mac에서 처음 열 때 Gatekeeper 경고가 표시될 수 있습니다.

## Test environment / 검증 환경

- App: Wuma Tracker `v1.5.3`
- Active offset shown during test: `mac:v3.3.0`
- macOS: `26.5` (`25F71`)
- Mac model: MacBook Pro (`Mac17,2`)
- Chip/arch: Apple M5, `arm64`
- Memory: 24 GB

## Screenshots / 검증 스크린샷

Chrome address/tab area and in-game UID are masked before upload.

![Web map tracking result](https://raw.githubusercontent.com/gudcks0305/wuma-tracker/pr-assets-macos-tracker-support/screenshots/01-web-map-masked.jpg)

![In-game map position](https://raw.githubusercontent.com/gudcks0305/wuma-tracker/pr-assets-macos-tracker-support/screenshots/02-game-map-redacted.jpg)

![In-game world position](https://raw.githubusercontent.com/gudcks0305/wuma-tracker/pr-assets-macos-tracker-support/screenshots/03-game-world-redacted.jpg)

## Verification

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pnpm tauri build --debug --bundles app --config '{"bundle":{"createUpdaterArtifacts":false,"macOS":{"signingIdentity":"-"}}}'`
- `pnpm tauri build --debug --bundles dmg --config '{"bundle":{"createUpdaterArtifacts":false,"macOS":{"signingIdentity":"-"}}}'`
- verified the generated DMG contains an app executable with `com.apple.security.cs.debugger=true`
- verified no `pgrep`, `vmmap`, or `nm` process spawning remains in `src-tauri/src`
- manually tested attaching to the macOS game process and reading player coordinates

## 검증

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pnpm tauri build --debug --bundles app --config '{"bundle":{"createUpdaterArtifacts":false,"macOS":{"signingIdentity":"-"}}}'`
- `pnpm tauri build --debug --bundles dmg --config '{"bundle":{"createUpdaterArtifacts":false,"macOS":{"signingIdentity":"-"}}}'`
- 생성된 DMG 안의 앱 실행 파일에 `com.apple.security.cs.debugger=true` entitlement가 들어간 것을 확인했습니다.
- `src-tauri/src`에 `pgrep`, `vmmap`, `nm` 프로세스 실행 경로가 남아 있지 않은 것을 확인했습니다.
- macOS 명조 게임 프로세스에 직접 attach해서 플레이어 좌표가 읽히는 것을 확인했습니다.
