### PR TITLE
Fix macOS CI DMG signing config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,10 @@ jobs:
             args: ""
             rust-targets: ""
           - platform: "macos-latest"
-            args: "--target universal-apple-darwin"
+            args: >-
+              --target universal-apple-darwin
+              --bundles dmg
+              --config '{"bundle":{"createUpdaterArtifacts":false,"macOS":{"signingIdentity":"-"}}}'
             rust-targets: "aarch64-apple-darwin,x86_64-apple-darwin"
 
     runs-on: ${{ matrix.platform }}

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Tauri, SvelteKit, TypeScript를 기반으로 제작되었습니다.
     ```
 
     이 방식은 Developer ID 서명과 notarization을 거치지 않으므로, 다른 Mac에서 처음 열 때 Gatekeeper 경고가 표시될 수 있습니다.
+    배포 환경에 따라 서명 방식과 notarization 설정은 별도로 조정하세요.
 
 -----
 


### PR DESCRIPTION
## Summary
- add macOS CI args for universal DMG builds with ad-hoc signing
- disable updater artifact creation for the macOS DMG job
- clarify that local macOS signing/notarization can vary by distribution environment

## Validation
- git diff --check

## Notes
- Commit author/committer email is `gudcks305@gmail.com`.
- No co-author trailer was added.